### PR TITLE
Automatic selection of the first tab when resizing fixed

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -80,8 +80,8 @@
             $parentLi.append($panelHeading);
         });
 
-        if (!$('li').hasClass('active')) {
-            $('li').first().addClass('active')
+        if (!this.$tabs.find('li').hasClass('active')) {
+            this.$tabs.find('li').first().addClass('active')
         }
 
         var $panelBodies = this.$accordion.find('.js-tabcollapse-panel-body');


### PR DESCRIPTION
Automatic selection of the first tab when resizing the screen from small to large (showTabs) needs some context to avoid marking the wrong li tag as active.